### PR TITLE
feat: add support for root attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/compspec/compspec/tree/main) (0.0.x)
- - read_file added to utils (0.0.12)
- - jgf (json graph format) generation added (0.0.11)
+ - support for attributes when creating root (0.1.13)
+ - read_file added to utils (0.1.12)
+ - jgf (json graph format) generation added (0.1.11)
  - add support for generic create (not compat artifact) (0.1.1)
  - new release with compatibility artifacts (0.1.0)
  - added is_connector type of node fact to skip irrelevant roots (0.0.14)

--- a/compspec/create/jsongraph.py
+++ b/compspec/create/jsongraph.py
@@ -133,9 +133,11 @@ class JsonGraph:
         self.add_edge(source, target, "contains")
         self.add_edge(target, source, "in")
 
-    def generate_root(self):
+    def generate_root(self, attributes=None):
         """
         Generate the root cluster node
         """
         idx = self.next_count
-        return self.add_node(typ=self.name, path=f"/{self.name}{idx}", idx=idx)
+        return self.add_node(
+            typ=self.name, path=f"/{self.name}{idx}", idx=idx, attributes=attributes
+        )

--- a/compspec/create/jsongraph.py
+++ b/compspec/create/jsongraph.py
@@ -23,6 +23,7 @@ class JsonGraph:
         self.counter = 0
         self.nodes = {}
         self.edges = []
+        self.metadata = {}
 
         # Keep track of count for each type
         self.resource_counts = {}
@@ -37,7 +38,7 @@ class JsonGraph:
         """
         Render generates the artifact, adding all unique schemas and compatibility sections
         """
-        metadata = metadata or {}
+        metadata = self.metadata or {}
         g = {"graph": {"nodes": self.nodes, "edges": self.edges}}
         if metadata:
             g["metadata"] = metadata
@@ -133,11 +134,14 @@ class JsonGraph:
         self.add_edge(source, target, "contains")
         self.add_edge(target, source, "in")
 
-    def generate_root(self, attributes=None):
+    def generate_root(self, attributes=None, typ=None):
         """
         Generate the root cluster node
         """
         idx = self.next_count
         return self.add_node(
-            typ=self.name, path=f"/{self.name}{idx}", idx=idx, attributes=attributes
+            typ=typ or self.name,
+            path=f"/{self.name}{idx}",
+            idx=idx,
+            attributes=attributes,
         )

--- a/compspec/version.py
+++ b/compspec/version.py
@@ -2,7 +2,7 @@ __author__ = "Vanessa Sochat"
 __copyright__ = "Copyright 2022-2024, Vanessa Sochat"
 __license__ = "MIT"
 
-__version__ = "0.1.12"
+__version__ = "0.1.13"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "compspec"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [tool.black]
-profile = "black"
-exclude = ["^env/"]
+exclude = "^env/"
 
 [tool.isort]
 profile = "black" # needed for black/isort compatibility


### PR DESCRIPTION
We should be able to provide metadata that is needed to discover the spack install (or similar software) in the root.